### PR TITLE
Refer to targets instead of using a glob

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,5 @@
 cc_library(
     name="nectar-lib",
-    hdrs = glob([
-        "nectar/*.h",
-    ]),
+    deps=["//nectar:common"],
     visibility = ["//visibility:public"],    
 )

--- a/nectar/BUILD
+++ b/nectar/BUILD
@@ -23,3 +23,15 @@ cc_library(
     hdrs = ["collections.h"],
     visibility = ["//visibility:public"],
 )
+
+cc_library(
+    name = "common",
+    hdrs = ["common.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "collections",
+        "cpp20",
+        "cstring_view",
+        "scoper",
+    ],
+)


### PR DESCRIPTION
This seems to avoid the header problem mentioned [here](https://github.com/BeeswaxIO/beeswaxio/pull/32010/files#r928138806).